### PR TITLE
feat(backend): add comprehensive TypeScript interfaces and types

### DIFF
--- a/backend/src/types/assessment.ts
+++ b/backend/src/types/assessment.ts
@@ -1,0 +1,362 @@
+import { 
+  BaseDocument, 
+  AssessmentLevel, 
+  AssessmentStep, 
+  AssessmentStatus, 
+  DigitalCompetency, 
+  QuestionType,
+  CertificateStatus 
+} from './index';
+
+// Question Interface
+export interface Question extends BaseDocument {
+  questionText: string;
+  questionType: QuestionType;
+  competency: DigitalCompetency;
+  level: AssessmentLevel;
+  step: AssessmentStep;
+  
+  // Multiple choice options
+  options?: QuestionOption[];
+  
+  // Correct answer(s)
+  correctAnswers: string[];
+  
+  // Question metadata
+  difficulty: number; // 1-5 scale
+  timeAllowed: number; // in minutes
+  points: number;
+  
+  // Additional data
+  explanation?: string;
+  tags?: string[];
+  isActive: boolean;
+  
+  // Media attachments
+  imageUrl?: string;
+  audioUrl?: string;
+  videoUrl?: string;
+  
+  // Question statistics
+  timesAnswered: number;
+  correctAnswerRate: number;
+}
+
+export interface QuestionOption {
+  id: string;
+  text: string;
+  isCorrect: boolean;
+  order: number;
+}
+
+// Assessment Session Interface
+export interface AssessmentSession extends BaseDocument {
+  userId: string;
+  step: AssessmentStep;
+  status: AssessmentStatus;
+  
+  // Questions for this session
+  questions: AssessmentQuestion[];
+  
+  // Timing
+  startTime: Date;
+  endTime?: Date;
+  timeAllowed: number; // Total time in minutes
+  timeRemaining?: number; // Remaining time in seconds
+  
+  // Answers
+  answers: AssessmentAnswer[];
+  
+  // Results
+  score?: number;
+  percentage?: number;
+  levelAchieved?: AssessmentLevel;
+  passed: boolean;
+  
+  // Next step eligibility
+  canProceedToNextStep: boolean;
+  nextStepUnlockedAt?: Date;
+  
+  // Session metadata
+  ipAddress?: string;
+  userAgent?: string;
+  browserFingerprint?: string;
+  
+  // Security flags
+  isCompleted: boolean;
+  isSubmitted: boolean;
+  hasCheatingFlags: boolean;
+  cheatingDetails?: CheatingFlag[];
+}
+
+export interface AssessmentQuestion {
+  questionId: string;
+  order: number;
+  competency: DigitalCompetency;
+  level: AssessmentLevel;
+  points: number;
+  timeAllowed: number;
+  
+  // For display during assessment
+  questionText: string;
+  questionType: QuestionType;
+  options?: QuestionOption[];
+  
+  // Media
+  imageUrl?: string;
+  audioUrl?: string;
+  videoUrl?: string;
+}
+
+export interface AssessmentAnswer {
+  questionId: string;
+  selectedAnswers: string[];
+  timeSpent: number; // in seconds
+  isCorrect: boolean;
+  pointsEarned: number;
+  answeredAt: Date;
+  
+  // For tracking user behavior
+  changedAnswers: number;
+  tabSwitches: number;
+  copyPasteDetected: boolean;
+}
+
+export interface CheatingFlag {
+  type: 'tab_switch' | 'copy_paste' | 'suspicious_timing' | 'multiple_sessions' | 'network_change';
+  details: string;
+  timestamp: Date;
+  severity: 'low' | 'medium' | 'high';
+}
+
+// Assessment Progress Interface
+export interface AssessmentProgress extends BaseDocument {
+  userId: string;
+  
+  // Overall progress
+  currentStep: AssessmentStep;
+  highestLevelAchieved: AssessmentLevel;
+  
+  // Step-wise progress
+  step1Completed: boolean;
+  step1Score?: number;
+  step1Level?: AssessmentLevel;
+  step1CompletedAt?: Date;
+  
+  step2Completed: boolean;
+  step2Score?: number;
+  step2Level?: AssessmentLevel;
+  step2CompletedAt?: Date;
+  
+  step3Completed: boolean;
+  step3Score?: number;
+  step3Level?: AssessmentLevel;
+  step3CompletedAt?: Date;
+  
+  // Overall statistics
+  totalAssessmentsTaken: number;
+  totalTimeSpent: number; // in minutes
+  averageScore: number;
+  
+  // Competency-wise scores
+  competencyScores: CompetencyScore[];
+  
+  // Restrictions
+  canRetakeStep1: boolean;
+  nextAssessmentDate?: Date;
+  
+  // Achievement tracking
+  achievements: Achievement[];
+}
+
+export interface CompetencyScore {
+  competency: DigitalCompetency;
+  score: number;
+  level: AssessmentLevel;
+  questionsAttempted: number;
+  correctAnswers: number;
+  lastUpdated: Date;
+}
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  type: 'level' | 'speed' | 'accuracy' | 'streak' | 'special';
+  unlockedAt: Date;
+  iconUrl?: string;
+}
+
+// Certificate Interface
+export interface Certificate extends BaseDocument {
+  userId: string;
+  assessmentSessionId: string;
+  
+  // Certificate details
+  certificateNumber: string;
+  level: AssessmentLevel;
+  status: CertificateStatus;
+  
+  // Scoring details
+  score: number;
+  percentage: number;
+  competencyBreakdown: CompetencyScore[];
+  
+  // Dates
+  issuedAt: Date;
+  expiresAt?: Date;
+  validatedAt?: Date;
+  
+  // Certificate file
+  certificateUrl?: string;
+  verificationCode: string;
+  
+  // Issuer information
+  issuedBy: string;
+  issuerTitle: string;
+  issuerSignature?: string;
+  
+  // Verification
+  isVerified: boolean;
+  verificationDetails?: {
+    verifiedBy: string;
+    verifiedAt: Date;
+    notes?: string;
+  };
+  
+  // Sharing
+  isPublic: boolean;
+  shareUrl?: string;
+  downloadCount: number;
+}
+
+// Request/Response Interfaces
+
+// Start Assessment Request
+export interface StartAssessmentRequest {
+  step: AssessmentStep;
+}
+
+export interface StartAssessmentResponse {
+  sessionId: string;
+  questions: AssessmentQuestion[];
+  timeAllowed: number;
+  totalQuestions: number;
+  step: AssessmentStep;
+}
+
+// Submit Answer Request
+export interface SubmitAnswerRequest {
+  sessionId: string;
+  questionId: string;
+  selectedAnswers: string[];
+  timeSpent: number;
+}
+
+// Submit Assessment Request
+export interface SubmitAssessmentRequest {
+  sessionId: string;
+  answers: AssessmentAnswer[];
+  totalTimeSpent: number;
+}
+
+export interface AssessmentResultResponse {
+  sessionId: string;
+  score: number;
+  percentage: number;
+  levelAchieved: AssessmentLevel;
+  passed: boolean;
+  canProceedToNextStep: boolean;
+  
+  // Detailed breakdown
+  competencyResults: CompetencyResult[];
+  timeSpent: number;
+  correctAnswers: number;
+  totalQuestions: number;
+  
+  // Next steps
+  nextStepAvailable: boolean;
+  nextStepUnlocksAt?: Date;
+  certificateGenerated: boolean;
+  certificateId?: string;
+}
+
+export interface CompetencyResult {
+  competency: DigitalCompetency;
+  score: number;
+  totalQuestions: number;
+  correctAnswers: number;
+  level: AssessmentLevel;
+}
+
+// Assessment Statistics
+export interface AssessmentStatistics {
+  totalAssessments: number;
+  completedAssessments: number;
+  averageScore: number;
+  averageCompletionTime: number;
+  
+  // By step
+  step1Stats: StepStatistics;
+  step2Stats: StepStatistics;
+  step3Stats: StepStatistics;
+  
+  // By level
+  levelDistribution: Record<AssessmentLevel, number>;
+  
+  // Pass rates
+  overallPassRate: number;
+  passRateByStep: Record<AssessmentStep, number>;
+}
+
+export interface StepStatistics {
+  totalAttempts: number;
+  completedAttempts: number;
+  averageScore: number;
+  passRate: number;
+  averageCompletionTime: number;
+}
+
+// Admin Question Management
+export interface CreateQuestionRequest {
+  questionText: string;
+  questionType: QuestionType;
+  competency: DigitalCompetency;
+  level: AssessmentLevel;
+  step: AssessmentStep;
+  options?: Omit<QuestionOption, 'id'>[];
+  correctAnswers: string[];
+  difficulty: number;
+  timeAllowed: number;
+  points: number;
+  explanation?: string;
+  tags?: string[];
+  imageUrl?: string;
+  audioUrl?: string;
+  videoUrl?: string;
+}
+
+export interface UpdateQuestionRequest extends Partial<CreateQuestionRequest> {
+  isActive?: boolean;
+}
+
+export interface QuestionQuery {
+  competency?: DigitalCompetency;
+  level?: AssessmentLevel;
+  step?: AssessmentStep;
+  questionType?: QuestionType;
+  difficulty?: number;
+  isActive?: boolean;
+  search?: string;
+}
+
+// Bulk Question Operations
+export interface BulkQuestionAction {
+  questionIds: string[];
+  action: 'activate' | 'deactivate' | 'delete' | 'export';
+}
+
+export interface ImportQuestionsRequest {
+  questions: CreateQuestionRequest[];
+  overwriteExisting: boolean;
+}

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -1,0 +1,245 @@
+import { BaseDocument, UserRole, OTPData } from './index';
+
+// User Profile Interface
+export interface UserProfile extends BaseDocument {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  role: UserRole;
+  isEmailVerified: boolean;
+  isActive: boolean;
+  lastLogin?: Date;
+  profilePicture?: string;
+  
+  // Security fields
+  loginAttempts: number;
+  lockUntil?: Date;
+  passwordResetToken?: string;
+  passwordResetExpires?: Date;
+  emailVerificationToken?: string;
+  emailVerificationExpires?: Date;
+  
+  // OTP for two-factor authentication
+  otp?: OTPData;
+  
+  // Assessment Progress
+  assessmentProgress?: {
+    currentStep: number;
+    highestLevelAchieved: string;
+    lastAssessmentDate?: Date;
+    totalAssessmentsTaken: number;
+  };
+  
+  // Metadata
+  registrationIP?: string;
+  lastLoginIP?: string;
+  preferredLanguage?: string;
+  timezone?: string;
+}
+
+// Registration Request
+export interface RegisterRequest {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  role?: UserRole;
+  preferredLanguage?: string;
+  timezone?: string;
+}
+
+// Login Request
+export interface LoginRequest {
+  email: string;
+  password: string;
+  rememberMe?: boolean;
+}
+
+// Login Response
+export interface LoginResponse {
+  user: UserSafeProfile;
+  tokens: {
+    accessToken: string;
+    refreshToken: string;
+    expiresIn: number;
+  };
+}
+
+// User Safe Profile (without sensitive data)
+export interface UserSafeProfile {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: UserRole;
+  isEmailVerified: boolean;
+  isActive: boolean;
+  lastLogin?: Date;
+  profilePicture?: string;
+  assessmentProgress?: {
+    currentStep: number;
+    highestLevelAchieved: string;
+    lastAssessmentDate?: Date;
+    totalAssessmentsTaken: number;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Forgot Password Request
+export interface ForgotPasswordRequest {
+  email: string;
+}
+
+// Reset Password Request
+export interface ResetPasswordRequest {
+  token: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+// Change Password Request
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+// Update Profile Request
+export interface UpdateProfileRequest {
+  firstName?: string;
+  lastName?: string;
+  preferredLanguage?: string;
+  timezone?: string;
+  profilePicture?: string;
+}
+
+// Email Verification Request
+export interface EmailVerificationRequest {
+  token: string;
+}
+
+// OTP Verification Request
+export interface OTPVerificationRequest {
+  email: string;
+  otp: string;
+  action: 'login' | 'registration' | 'password_reset' | 'email_change';
+}
+
+// Send OTP Request
+export interface SendOTPRequest {
+  email: string;
+  action: 'login' | 'registration' | 'password_reset' | 'email_change';
+  method: 'email' | 'sms';
+  phoneNumber?: string;
+}
+
+// Refresh Token Request
+export interface RefreshTokenRequest {
+  refreshToken: string;
+}
+
+// JWT Token Payload
+export interface JWTTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+// Account Lock Information
+export interface AccountLockInfo {
+  isLocked: boolean;
+  lockUntil?: Date;
+  remainingAttempts: number;
+  lockReason?: string;
+}
+
+// User Activity Log
+export interface UserActivity {
+  userId: string;
+  action: string;
+  details?: any;
+  ipAddress?: string;
+  userAgent?: string;
+  timestamp: Date;
+}
+
+// Social Login (if needed later)
+export interface SocialLoginRequest {
+  provider: 'google' | 'facebook' | 'linkedin';
+  accessToken: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  profilePicture?: string;
+}
+
+// Admin User Management
+export interface AdminUserQuery {
+  search?: string;
+  role?: UserRole;
+  isActive?: boolean;
+  isEmailVerified?: boolean;
+  registrationDateFrom?: Date;
+  registrationDateTo?: Date;
+  lastLoginFrom?: Date;
+  lastLoginTo?: Date;
+}
+
+export interface BulkUserAction {
+  userIds: string[];
+  action: 'activate' | 'deactivate' | 'delete' | 'verify_email' | 'reset_password';
+  reason?: string;
+}
+
+// Two-Factor Authentication
+export interface TwoFactorSetupRequest {
+  method: 'email' | 'sms';
+  phoneNumber?: string;
+}
+
+export interface TwoFactorVerificationRequest {
+  userId: string;
+  code: string;
+  method: 'email' | 'sms';
+}
+
+// Session Management
+export interface UserSession {
+  userId: string;
+  sessionId: string;
+  deviceInfo: {
+    userAgent: string;
+    ip: string;
+    device: string;
+    os: string;
+    browser: string;
+  };
+  isActive: boolean;
+  lastActivity: Date;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+// Password Policy
+export interface PasswordPolicy {
+  minLength: number;
+  requireUppercase: boolean;
+  requireLowercase: boolean;
+  requireNumbers: boolean;
+  requireSpecialChars: boolean;
+  preventReuse: number; // Number of previous passwords to prevent reuse
+}
+
+// Account Statistics
+export interface UserStatistics {
+  totalUsers: number;
+  activeUsers: number;
+  verifiedUsers: number;
+  usersRegisteredToday: number;
+  usersRegisteredThisWeek: number;
+  usersRegisteredThisMonth: number;
+  usersByRole: Record<UserRole, number>;
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,188 @@
+// Base API Response Interface
+export interface ApiResponse<T = any> {
+  success: boolean;
+  message: string;
+  data?: T;
+  error?: string;
+  timestamp: string;
+  version: string;
+}
+
+// Pagination Interface
+export interface PaginationQuery {
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: {
+    currentPage: number;
+    totalPages: number;
+    totalItems: number;
+    itemsPerPage: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+  };
+}
+
+// User Roles Enum
+export enum UserRole {
+  ADMIN = 'admin',
+  STUDENT = 'student',
+  SUPERVISOR = 'supervisor'
+}
+
+// Assessment Levels Enum (A1 → C2)
+export enum AssessmentLevel {
+  A1 = 'A1',
+  A2 = 'A2',
+  B1 = 'B1',
+  B2 = 'B2',
+  C1 = 'C1',
+  C2 = 'C2'
+}
+
+// Assessment Steps Enum
+export enum AssessmentStep {
+  STEP_1 = 1, // A1 & A2
+  STEP_2 = 2, // B1 & B2  
+  STEP_3 = 3  // C1 & C2
+}
+
+// Assessment Status Enum
+export enum AssessmentStatus {
+  NOT_STARTED = 'not_started',
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  EXPIRED = 'expired'
+}
+
+// Certificate Status Enum
+export enum CertificateStatus {
+  PENDING = 'pending',
+  ISSUED = 'issued',
+  REVOKED = 'revoked'
+}
+
+// Digital Competencies (22 total)
+export enum DigitalCompetency {
+  // Information Literacy
+  INFORMATION_SEARCH = 'information_search',
+  INFORMATION_EVALUATION = 'information_evaluation',
+  DATA_MANAGEMENT = 'data_management',
+  
+  // Communication & Collaboration
+  DIGITAL_COMMUNICATION = 'digital_communication',
+  ONLINE_COLLABORATION = 'online_collaboration',
+  SOCIAL_MEDIA_LITERACY = 'social_media_literacy',
+  
+  // Content Creation
+  CONTENT_DEVELOPMENT = 'content_development',
+  MULTIMEDIA_EDITING = 'multimedia_editing',
+  COPYRIGHT_LICENSING = 'copyright_licensing',
+  
+  // Safety & Security
+  DEVICE_PROTECTION = 'device_protection',
+  PERSONAL_DATA_PROTECTION = 'personal_data_protection',
+  PRIVACY_MANAGEMENT = 'privacy_management',
+  HEALTH_WELLBEING = 'health_wellbeing',
+  ENVIRONMENTAL_PROTECTION = 'environmental_protection',
+  
+  // Problem Solving
+  TECHNICAL_TROUBLESHOOTING = 'technical_troubleshooting',
+  IDENTIFYING_NEEDS = 'identifying_needs',
+  CREATIVE_USE_OF_TECHNOLOGY = 'creative_use_of_technology',
+  IDENTIFYING_GAPS = 'identifying_gaps',
+  
+  // Software Proficiency
+  OPERATING_SYSTEMS = 'operating_systems',
+  OFFICE_PRODUCTIVITY = 'office_productivity',
+  WEB_BROWSERS = 'web_browsers',
+  MOBILE_APPLICATIONS = 'mobile_applications'
+}
+
+// Question Types
+export enum QuestionType {
+  MULTIPLE_CHOICE = 'multiple_choice',
+  TRUE_FALSE = 'true_false',
+  SCENARIO = 'scenario',
+  PRACTICAL = 'practical'
+}
+
+// Base MongoDB Document Interface
+export interface BaseDocument {
+  _id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Error Types
+export interface ValidationError {
+  field: string;
+  message: string;
+  value?: any;
+}
+
+export interface AppError extends Error {
+  statusCode: number;
+  status: string;
+  isOperational: boolean;
+  errors?: ValidationError[];
+}
+
+// JWT Payload Interface
+export interface JWTPayload {
+  userId: string;
+  email: string;
+  role: UserRole;
+  iat?: number;
+  exp?: number;
+}
+
+// OTP Interface
+export interface OTPData {
+  code: string;
+  expiresAt: Date;
+  attempts: number;
+  isUsed: boolean;
+}
+
+// File Upload Interface
+export interface FileUpload {
+  fieldname: string;
+  originalname: string;
+  encoding: string;
+  mimetype: string;
+  size: number;
+  destination: string;
+  filename: string;
+  path: string;
+}
+
+// Request Extensions
+export interface AuthenticatedRequest extends Request {
+  user: {
+    id: string;
+    email: string;
+    role: UserRole;
+  };
+}
+
+// Common Query Filters
+export interface DateRangeFilter {
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export interface ScoreRangeFilter {
+  minScore?: number;
+  maxScore?: number;
+}
+
+// Export all types
+export * from './auth';
+export * from './assessment';


### PR DESCRIPTION
- Define base types for API responses, pagination, and enums
- Add complete authentication types for users, sessions, and security
- Create assessment types for questions, sessions, progress, and certificates
- Include 22 digital competencies and A1-C2 assessment levels
- Set up type safety foundation for entire platform

All models and controllers will use these strongly-typed interfaces.